### PR TITLE
Use UTF-8 file encoding

### DIFF
--- a/geo.py
+++ b/geo.py
@@ -52,8 +52,8 @@ def create_activities_map_file(activities_dataframe):
     activities_map_dataframe.loc[:, 'map_linestring'] = activities_map_dataframe.loc[:, 'map_points'].apply(LineString)
 
     # Create a GeoDataFrame from the activities map DataFrame
-    activities_map_geodataframe = GeoDataFrame(activities_map_dataframe[['id', 'type', 'distance', 'total_elevation_gain', 'map_linestring']], geometry = 'map_linestring')
+    activities_map_geodataframe = GeoDataFrame(activities_map_dataframe[['name', 'id', 'type', 'distance', 'total_elevation_gain', 'map_linestring']], geometry = 'map_linestring')
 
     # Export the GeoDataFrame to a file in GeoJSON format
     print('Geo: Exporting map data to {}'.format(STRAVA_ACTIVITIES_MAP_FILE))
-    activities_map_geodataframe.to_file(STRAVA_ACTIVITIES_MAP_FILE, driver = 'GeoJSON')
+    activities_map_geodataframe.to_file(STRAVA_ACTIVITIES_MAP_FILE, driver = 'GeoJSON', encoding = 'utf8')

--- a/strava_activities.py
+++ b/strava_activities.py
@@ -66,7 +66,7 @@ def read_activities_from_file(activities_list):
 
     activities_read = 0
     try:
-        with open(STRAVA_ACTIVITIES_FILE, 'r') as file:
+        with open(STRAVA_ACTIVITIES_FILE, 'r', encoding = 'utf8') as file:
             for data in file.readlines():
                 print('Strava: Reading activity {}'.format(activities_read), end = "\r")
 
@@ -91,9 +91,9 @@ def write_activities_to_file(activities):
         os.makedirs('Data')
 
     # Append the activities to the file in JSON format
-    with open(STRAVA_ACTIVITIES_FILE, 'a+') as file:
+    with open(STRAVA_ACTIVITIES_FILE, 'a+', encoding = 'utf8') as file:
         for data in activities:
-            file.write(json.dumps(data, cls = datetime_to_iso))
+            file.write(json.dumps(data, cls = datetime_to_iso, ensure_ascii = False))
             file.write('\n')
 
 def get_last_activity_start_time(activities_list):


### PR DESCRIPTION
Forces the use of UTF-8 encoding to read from and write to all files. This is required to support the full set of characters used in Strava activity names.