### PR TITLE
Check for empty polyline when generating geo data file

### DIFF
--- a/geo.py
+++ b/geo.py
@@ -26,10 +26,11 @@ def _decode_polyline(x: pandas.Series) -> list:
     A list of decoded coordinates from the polyline.
     """
 
-    if x['polyline'] is not None:
-        map_coordinates = polyline.decode(x['polyline'])
+    # Check for both null and empty polyline strings
+    if not x['polyline'] or x['polyline'] is None:
+        map_coordinates = None
     else:
-        map_coordinates = None    
+        map_coordinates = polyline.decode(x['polyline'])
     
     return map_coordinates
 


### PR DESCRIPTION
Checks for the presence of empty polyline strings when generating a geo data file and prevents the corresponding activities from being included as described in issue #31.