### PR TITLE
Use Strava-provided rate limit headers to do smarter retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ venv.bak/
 
 # Visual Studio Code settings
 .vscode/settings.json
+
+/strava-analysis-tool/

--- a/analysis.py
+++ b/analysis.py
@@ -13,10 +13,10 @@ display_mean_distance_plot()
 Felix van Oost 2020
 """
 
-# Standard library imports
+# Standard library
 import datetime
 
-# Third-party imports
+# Third-party
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import pandas as pd

--- a/config.toml
+++ b/config.toml
@@ -5,9 +5,6 @@ tokens_file = 'Tokens.txt'
 activity_data_file = 'Data/StravaActivityData.json'
 geo_data_file = 'Data/StravaGeoData.geojson'
 
-[strava]
-retry_interval_sec = 120
-
 [analysis]
 plot_colour_palette = ["#2C3E50", "#E74C3C", "#ECF0F1", "#3498DB", "#2980B9",
                        "#195962", "#F56F6C", "#FFFFFF", "#252932", "#191C21"]

--- a/geo.py
+++ b/geo.py
@@ -8,7 +8,7 @@ export_geo_data_file()
 Felix van Oost 2020
 """
 
-# Third-party imports
+# Third-party
 from geopandas import GeoDataFrame
 import pandas
 import polyline

--- a/here_xyz.py
+++ b/here_xyz.py
@@ -9,7 +9,7 @@ upload_geo_data()
 Felix van Oost 2019
 """
 
-# Local imports
+# Local
 import subprocess
 
 
@@ -40,7 +40,7 @@ def _get_space_id() -> str:
 
         # Create a new space
         command = 'here xyz create -t "Strava Activity Data" -d "Created by Strava Heatmap Tool"'
-        space_id = subprocess.check_output(command, shell=True).decode('utf-8').split()[1]
+        space_id = subprocess.check_output(command, shell=True).decode('utf-8').split()[2]
         print('HERE XYZ: Created new space with ID "{}"'.format(space_id))
 
     return space_id
@@ -68,11 +68,11 @@ def upload_geo_data(file_path: str):
 
         # Clear the space to prevent conflicts in overwriting existing data
         print('HERE XYZ: Clearing space ID "{}"'.format(space_id))
-        process = subprocess.Popen(['here', 'xyz', 'clear', space_id.replace("'", "")],
+        process = subprocess.Popen(['here xyz clear {}'.format(space_id)],
                                 shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                 universal_newlines=True)
         process.stdout.reconfigure(encoding='utf-8')
-        clear_space_output = process.communicate(input='Y')[0]
+        clear_space_output, _ = process.communicate(input='Y')
 
         if 'data cleared successfully' in clear_space_output:
             # Upload the geospatial data to the space

--- a/strava_analysis_tool.py
+++ b/strava_analysis_tool.py
@@ -5,13 +5,13 @@ Main module for the Strava Analysis Tool.
 Felix van Oost 2020
 """
 
-# Standard library imports
+# Standard library
 import argparse
 
-# Third-party imports
+# Third-party
 import toml
 
-# Local imports
+# Local
 import analysis
 import here_xyz
 import geo
@@ -26,7 +26,6 @@ def main():
     Main method for the Strava Analysis Tool.
     """
 
-    # Parse the command line arguments
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-a', '--activity_count_plot',
                         action='store_const',
@@ -73,7 +72,6 @@ def main():
     # Get a list of detailed activity data for all Strava activities
     activity_data = strava_data.get_activity_data(config['paths']['tokens_file'],
                                                   config['paths']['activity_data_file'],
-                                                  config['strava']['retry_interval_sec'],
                                                   args.refresh_data)
 
     # Create a pandas DataFrame from the activity data

--- a/strava_auth.py
+++ b/strava_auth.py
@@ -8,12 +8,12 @@ get_access_token()
 Felix van Oost 2019
 """
 
-# Standard library imports
+# Standard library
 import os
 import time
 import webbrowser
 
-# Third-party imports
+# Third-party
 import requests
 from requests import Request
 

--- a/strava_data.py
+++ b/strava_data.py
@@ -29,7 +29,6 @@ def _iso_to_datetime(obj):
     """Deserialise ISO 8601 strings into datetime objects."""
 
     dictionary = {}
-
     for (key, value) in obj:
         # Check if the object is a string and attempt to parse it into a
         # datetime object


### PR DESCRIPTION
Strava provides default headers `X-RateLimit-Usage` and `X-RateLimit-Limit` to see the daily and 15-minute API rate limits. Instead of default to retrying every 2 minutes, change the retry to 15 minutes since at every `0 15 30 45` minute mark, the rate resets. 

Also clean up some redundant comments. 