### PR TITLE
Remove use of shell in subprocess

### DIFF
--- a/here_xyz.py
+++ b/here_xyz.py
@@ -41,7 +41,7 @@ def _get_space_id() -> str:
 
         # Create a new space
         command = [shutil.which('here'), 'xyz', 'create', '-t', '"Strava Activity Data"', '-d',
-                   '"Created by Strava Heatmap Tool"']
+                   '"Created by Strava Analysis Tool"']
         space_id = subprocess.check_output(command).decode('utf-8').split()[2]
         print('HERE XYZ: Created new space with ID "{}"'.format(space_id))
 

--- a/here_xyz.py
+++ b/here_xyz.py
@@ -71,9 +71,7 @@ def upload_geo_data(file_path: str):
         # Clear the space to prevent conflicts in overwriting existing data
         print('HERE XYZ: Clearing space ID "{}"'.format(space_id))
         process = subprocess.Popen([shutil.which('here'), 'xyz', 'clear', space_id],
-                                   stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                                   universal_newlines=True)
-        process.stdout.reconfigure(encoding='utf-8')
+                                   stdin=subprocess.PIPE, stdout=subprocess.PIPE, encoding='utf-8')
         clear_space_output, _ = process.communicate(input='Y')
 
         if 'data cleared successfully' in clear_space_output:

--- a/here_xyz.py
+++ b/here_xyz.py
@@ -78,8 +78,8 @@ def upload_geo_data(file_path: str):
             # Upload the geospatial data to the space
             print('HERE XYZ: Uploading geospatial data to space ID "{}"'.format(space_id))
             command = ([shutil.which('here'), 'xyz', 'upload', space_id, '--file', file_path,
-                       '--stream', '--id', '"id"', '--date', '"local start date"', '--datetag',
-                       'year,month,weekday'])
+                        '--stream', '--id', '"id"', '--date', '"local start date"', '--datetag',
+                        'year,month,weekday'])
             upload_output = subprocess.check_output(command).decode('utf-8')
             print('HERE XYZ: ' + upload_output)
 

--- a/here_xyz.py
+++ b/here_xyz.py
@@ -9,7 +9,8 @@ upload_geo_data()
 Felix van Oost 2019
 """
 
-# Local
+# Standard library
+import shutil
 import subprocess
 
 
@@ -27,8 +28,8 @@ def _get_space_id() -> str:
     print('HERE XYZ: Locating the Strava activity data space')
 
     # Get a list of existing spaces
-    command = 'here xyz list'
-    for line in subprocess.check_output(command, shell=True).decode('utf-8').split('\n'):
+    command = [shutil.which('here'), 'xyz', 'list']
+    for line in subprocess.check_output(command).decode('utf-8').split('\n'):
         # Check whether a 'Strava Activity Data' space already exists
         if 'Strava Activity Data' in line:
             space_id = line.split()[1]
@@ -39,8 +40,9 @@ def _get_space_id() -> str:
         print('HERE XYZ: No existing space found')
 
         # Create a new space
-        command = 'here xyz create -t "Strava Activity Data" -d "Created by Strava Heatmap Tool"'
-        space_id = subprocess.check_output(command, shell=True).decode('utf-8').split()[2]
+        command = [shutil.which('here'), 'xyz', 'create', '-t', '"Strava Activity Data"', '-d',
+                   '"Created by Strava Heatmap Tool"']
+        space_id = subprocess.check_output(command).decode('utf-8').split()[2]
         print('HERE XYZ: Created new space with ID "{}"'.format(space_id))
 
     return space_id
@@ -59,8 +61,8 @@ def upload_geo_data(file_path: str):
     # Check whether the HERE CLI has been properly configured.
     # The CLI will return an empty line if the HERE account information
     # has been validated.
-    command = 'here configure verify'
-    configure_verify_output = subprocess.check_output(command, shell=True).decode('utf-8')
+    command = [shutil.which('here'), 'configure', 'verify']
+    configure_verify_output = subprocess.check_output(command).decode('utf-8')
 
     if not configure_verify_output:
         # Get the ID of the space containing the geospatial activity data
@@ -68,8 +70,8 @@ def upload_geo_data(file_path: str):
 
         # Clear the space to prevent conflicts in overwriting existing data
         print('HERE XYZ: Clearing space ID "{}"'.format(space_id))
-        process = subprocess.Popen(['here xyz clear {}'.format(space_id)],
-                                   shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+        process = subprocess.Popen([shutil.which('here'), 'xyz', 'clear', space_id],
+                                   stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                    universal_newlines=True)
         process.stdout.reconfigure(encoding='utf-8')
         clear_space_output, _ = process.communicate(input='Y')
@@ -77,10 +79,11 @@ def upload_geo_data(file_path: str):
         if 'data cleared successfully' in clear_space_output:
             # Upload the geospatial data to the space
             print('HERE XYZ: Uploading geospatial data to space ID "{}"'.format(space_id))
-            command = ('here xyz upload ' + space_id + ' --file ' + file_path + ' --stream ' +
-                       '--id "id" --date "local start date" --datetag "year,month,weekday"')
-            upload_output = subprocess.check_output(command, shell=True).decode('utf-8')
-            print(upload_output)
+            command = ([shutil.which('here'), 'xyz', 'upload', space_id, '--file', file_path,
+                       '--stream', '--id', '"id"', '--date', '"local start date"', '--datetag',
+                       'year,month,weekday'])
+            upload_output = subprocess.check_output(command).decode('utf-8')
+            print('HERE XYZ: ' + upload_output)
 
             if not 'features uploaded to XYZ space' in upload_output:
                 print('HERE XYZ: Error uploading geospatial data to space ID "{}"'.format(space_id))


### PR DESCRIPTION
Removes the use of `shell=True` argument in all `subprocess` calls, which fixes some cross-platform compatibility issues (finally tested the tool on Linux!) and potential security vulnerabilities.