### PR TITLE
Pass geopandas dataframe to HERE XYZ directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The following command line options are available:
 | `-c / --commute_plots` | Generate and display plots of the commute data |
 | `-d / --mean_distance_plot` | Generate and display a plot of the mean activity distance over time |
 | `-g / --export_geo_data` | Export the geospatial activity data in GeoJSON format |
-| `-gu / --export_upload_geo_data` | Export the geospatial activity data in GeoJSON format and upload it to the HERE XYZ mapping platform |
+| `-u / --upload_geo_data` | Upload the geospatial activity data to HERE XYZ |
 | `-m / --moving_time_heatmap` | Generate and display a heatmap of moving time for each activity type |
 | `-r / --refresh_data` | Get and store a fresh copy of the activity data |
 | `--date_range_start` | Specify the start of a date range in ISO format |

--- a/geo.py
+++ b/geo.py
@@ -47,17 +47,13 @@ def _create_shapely_point(coordinates: pandas.Series) -> Point:
 
     return [Point(y, x) for x, y in coordinates]
 
-def export_geo_data_file(file_path: str, activity_dataframe: pandas.DataFrame):
+def create_geodataframe(activity_dataframe: pandas.DataFrame):
     """
-    Export a GeoJSON-encoded file of geospatial data from all activities.
-
-    The exported file contains the name, ID, type, distance, total
+    Create a pandas GeoDataFrame containing the name, ID, type, distance, total
     elevation gain, and a LineString representing the trace of each
     activity.
 
     Arguments:
-    file_path - The path of the file to export the geospatial activity
-                data to.
     activity_dataframe - A pandas DataFrame containing the activity data.
     """
 
@@ -106,6 +102,19 @@ def export_geo_data_file(file_path: str, activity_dataframe: pandas.DataFrame):
                                               'total_elevation_gain': 'total elevation gain (m)'},
                                      inplace=True)
 
+    return activity_map_geodataframe
+
+
+def export_geo_data_file(file_path: str, activity_geodataframe: GeoDataFrame):
+    """
+    Export a GeoJSON-encoded file of geospatial data from all activities.
+
+    Arguments:
+    file_path - The path of the file to export the geospatial activity
+                data to.
+    activity_geodataframe - A pandas DataFrame containing the activity data.
+    """
+
     # Export the GeoDataFrame to a file in GeoJSON format
-    print('[Geo]: Exporting geospatial data to {}'.format(file_path))
-    activity_map_geodataframe.to_file(file_path, driver='GeoJSON', encoding='utf8')
+    print("[Geo]: Exporting geospatial data to '{}'".format(file_path))
+    activity_geodataframe.to_file(file_path, driver='GeoJSON', encoding='utf8')

--- a/here_xyz.py
+++ b/here_xyz.py
@@ -14,6 +14,7 @@ import os
 import sys
 
 # Third-party
+from geopandas import GeoDataFrame
 import xyzspaces
 
 
@@ -53,14 +54,13 @@ def _get_space(xyz) -> object:
     return space_obj
 
 
-def upload_geo_data(file_path: str):
+def upload_geo_data(activity_geodataframe: GeoDataFrame):
     """
     Upload the geospatial data from Strava activities to the HERE XYZ mapping
     platform.
 
     Arguments:
-    file_path - The path of the file containing the geospatial activity
-                data in GeoJSON format.
+    activity_geodataframe - pandas GeoDataFrame containing the geospatial activity data.
     """
 
     try:
@@ -76,6 +76,6 @@ def upload_geo_data(file_path: str):
     print("[HERE XYZ]: Uploading geospatial data to space ID '{}'".format(space.info['id']))
 
     # Upload the geospatial data to the space
-    space.add_features_geojson(file_path, encoding='utf-8', features_size=500, chunk_size=5)
+    space.add_features_geopandas(activity_geodataframe, features_size=500, chunk_size=5)
 
     print("[HERE XYZ]: Data successfully uploaded to space ID '{}'".format(space.info['id']))

--- a/strava_analysis_tool.py
+++ b/strava_analysis_tool.py
@@ -45,11 +45,10 @@ def main():
                         action='store_true',
                         required=False,
                         help='Export the geospatial activity data in GeoJSON format')
-    parser.add_argument('-gu', '--export_upload_geo_data',
+    parser.add_argument('-u', '--upload_geo_data',
                         action='store_true',
                         required=False,
-                        help=('Export the geospatial activity data in GeoJSON format and upload it'
-                              ' to the HERE XYZ mapping platform'))
+                        help=('Upload the geospatial activity data to HERE XYZ'))
     parser.add_argument('-m', '--moving_time_heatmap',
                         action='store_true',
                         required=False,
@@ -112,14 +111,18 @@ def main():
     analysis.display_summary_statistics(activity_dataframe)
     analysis.display_commute_statistics(activity_dataframe)
 
-    if args.export_geo_data or args.export_upload_geo_data:
-        # Export the geospatial data from all activities in GeoJSON
-        # format
-        geo.export_geo_data_file(config['paths']['geo_data_file'], activity_dataframe)
+    if args.export_geo_data or args.upload_geo_data:
 
-        if args.export_upload_geo_data:
+        # Create a GeoDataFrame containing the geospatial data from all activities
+        activity_geodataframe = geo.create_geodataframe(activity_dataframe)
+
+        if args.export_geo_data:
+            # Export the geospatial data in GeoJSON format
+            geo.export_geo_data_file(config['paths']['geo_data_file'], activity_geodataframe)
+
+        if args.upload_geo_data:
             # Upload the geospatial data to HERE XYZ
-            here_xyz.upload_geo_data(config['paths']['geo_data_file'])
+            here_xyz.upload_geo_data(activity_geodataframe)
 
     if args.activity_count_plot:
         # Generate and display a plot of activity counts over time


### PR DESCRIPTION
Passes a geopandas `GeoDataFrame` directly when uploading to HERE XYZ as described in issue #84. This removes the now uneccessary intermediate step of exporting a `.geojson` file first, which reduces the amount of time needed to process and upload the data.

As part of these changes, the command line argument `-gu / --generate_upload_geo_data` is now split into two independent arguments `-g / --export_geo_data` and `-u / --upload_geo_data`.