### PR TITLE
Use new HERE platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,8 +103,8 @@ venv.bak/
 # mypy
 .mypy_cache/
 
-# Strava API tokens
-*Tokens.txt
+# Strava and HERE credentials
+/credentials
 
 # Strava activity data
 /Data

--- a/README.md
+++ b/README.md
@@ -52,13 +52,20 @@ After authorizing access, the browser will redirect to an invalid page (`http://
 When prompted, copy the `code` portion of the URL (`xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`) and paste it into the console. The tool will get and refresh its own OAuth2 tokens, so this only needs to be done once.
 
 ### 3. HERE account
-You will need to register for a free HERE developer account if you want the tool to leverage the capabilities of the [HERE Studio](https://studio.here.com/) mapping platform. HERE Studio provides a very slick way to visualise your Strava data with a variety of map styles and customized formatting rules. Here's a basic example:
+You will need to register for a free HERE platform account [here](https://platform.here.com/) if you want the tool to leverage the capabilities of [HERE Studio](https://platform.here.com/studio/). HERE Studio provides a very slick way to visualise your Strava data with a variety of map styles and customized formatting rules. Here's a basic example:
 
 [![Demo Activity Map](Media/Demo%20Activity%20Map.JPG)](https://studio.here.com/viewer/?project_id=d99c795f-b247-47f9-a67e-972255a02017)
 
 Once configured, the tool can automatically upload your Strava data to HERE to generate an up-to-date map of your activities. You can set rules to colour-code activities (by type or moving time, for instance) within the HERE Studio web app, and clicking on an activity will bring up some useful basic information (try it!).
 
-After creating a developer account, generate a new access token with all permissions for all spaces using [this](https://xyz.api.here.com/token-ui/accessmgmt.html) link and copy the token into an environment variable named `XYZ_TOKEN`.
+After creating an account, create a new HERE project + app and generate OAuth credentials as follows:
+
+1. From the main HERE platform page, click on 'HERE Studio'.
+2. Click on 'Create new map' and give your map a name. This will also create a HERE project with the same name.
+3. Return to the main HERE platform page, click on 'Access Manager', then navigate to the 'Apps' tab at the top of the page.
+4. Click on 'Register new app', then give it a name (e.g. 'Strava Analysis Tool').
+5. In the 'Default access to a project' section, select the project (map) you created in HERE Studio then click 'Register'.
+6. Click on the app you just created, then create a new set of OAuth 2.0 credentials using the 'Create credentials' button. Download and save the generated file to the `/Credentials` folder in your local copy of this repository.
 
 ## Usage
 

--- a/config.toml
+++ b/config.toml
@@ -1,12 +1,13 @@
 # Configuration file for the Strava Analysis Tool.
 
 [paths]
-tokens_file = 'Tokens.txt'
+strava_tokens_file = 'Credentials/Tokens.txt'
+here_creds_file = 'Credentials/credentials.properties'
 activity_data_file = 'Data/StravaActivityData.json'
 geo_data_file = 'Data/StravaGeoData.geojson'
 
 [data]
-enable_reverse_geocoding = false
+enable_reverse_geocoding = true
 
 [analysis]
 plot_colour_palette = "Dark2"

--- a/here_xyz.py
+++ b/here_xyz.py
@@ -6,76 +6,98 @@ mapping platform.
 Functions:
 upload_geo_data()
 
-Felix van Oost 2021
+Felix van Oost 2022
 """
 
 # Standard library
-import os
+import geojson
+import json
+import pathlib
 import sys
 
 # Third-party
-import xyzspaces
+from xyzspaces import IML
+from xyzspaces.iml.credentials import Credentials
 
 
-def _get_space(xyz) -> object:
+HERE_CATALOG_ID = "strava-analysis-tool"
+HERE_LAYER_ID = "strava-activity-data"
+
+
+def _get_here_iml(here_creds_file_path: pathlib.Path) -> IML:
     """
-    Get and return an instance of the space containing the Strava activity data
-    or create a new space if one does not currently exist.
-
-    Return:
-    An instance of the space containing the Strava activity data.
-    """
-
-    print('[HERE XYZ]: Locating the Strava activity data space')
-
-    # Get a list of existing spaces
-    spaces_list = xyz.spaces.list(owner='me')
-
-    # Search for an existing space with the name 'Strava Activity Data'
-    for space in spaces_list:
-        if space['title'] == 'Strava Activity Data':
-            space_id = space['id']
-
-            print("[HERE XYZ]: Found space with ID '{}'".format(space_id))
-
-            space_obj = xyz.spaces.from_id(space_id)
-            break
-
-    if not space_obj:
-        print('[HERE XYZ]: No existing space found')
-
-        # Create a new space
-        space_obj = xyz.spaces.new(title='Strava Activity Data',
-                                   description='Created by Strava Analysis Tool')
-
-        print("[HERE XYZ]: Created new space with ID '{}'".format(space_obj.info['id']))
-
-    return space_obj
-
-
-def upload_geo_data(file_path: str):
-    """
-    Upload the geospatial data from Strava activities to the HERE XYZ mapping
-    platform.
+    Return an IML object for the HERE interactive map layer that belongs to the
+    Strava Analysis Tool. Create a new IML if one does not exist,
 
     Arguments:
-    file_path - The path of the file containing the geospatial activity
-                data in GeoJSON format.
+    here_creds_file_path - Path of the file containing the HERE platform
+                           credentials.
     """
 
+    # Get the HERE platform credentials
+    credentials = Credentials.from_credentials_file(here_creds_file_path)
+
+    # Attempt to load an instance of the existing interactive map layer (if
+    # one exists)
     try:
-        xyz_token = os.environ['XYZ_TOKEN']
-    except KeyError:
-        sys.exit('[ERROR]: Add XYZ_TOKEN to your environment variables')
+        print("[HERE] Locating the HERE interactive map layer for Strava "
+              "Analysis Tool")
 
-    xyz = xyzspaces.XYZ(credentials=xyz_token)
+        iml = IML.from_catalog_hrn_and_layer_id(
+        catalog_hrn=f"hrn:here:data:::{HERE_CATALOG_ID}",
+        layer_id=HERE_LAYER_ID,
+        credentials=credentials)
 
-    # Get the space containing the geospatial activity data
-    space = _get_space(xyz)
+        print("[HERE] Found an existing HERE interactive map layer with ID "
+              f"'{HERE_LAYER_ID}'")
+    except Exception as error:
+        print("[HERE] No existing HERE interactive map layer found. Creating a "
+              "new catalog and IML for Strava Analysis Tool.")
 
-    print("[HERE XYZ]: Uploading geospatial data to space ID '{}'".format(space.info['id']))
+        # Attempt to create a new catalog and IML for Strava Analysis Tool
+        try:
+            layer_details = {
+            "id": HERE_LAYER_ID,
+            "name": "Strava Activity Data",
+            "summary": "Strava Activity Data",
+            "description": "Strava data collected by Strava Analysis Tool",
+            "layerType": "interactivemap",
+            "interactiveMapProperties": {},
+            }
 
-    # Upload the geospatial data to the space
-    space.add_features_geojson(file_path, encoding='utf-8', features_size=500, chunk_size=5)
+            iml = IML.new(
+            catalog_id=HERE_CATALOG_ID,
+            catalog_name="Strava Analysis Tool",
+            catalog_summary="Strava Analysis Tool",
+            catalog_description="Strava data collected by Strava Analysis "
+                                "Tool",
+            layer_details=layer_details,
+            credentials=credentials,
+            )
 
-    print("[HERE XYZ]: Data successfully uploaded to space ID '{}'".format(space.info['id']))
+            print(f"[HERE] Created a new catalog with ID '{HERE_CATALOG_ID}' "
+                  f"and interactive map layer with ID '{HERE_LAYER_ID}'")
+        except Exception as error:
+            sys.exit(f'[ERROR]: HERE returned the following error: {error}')
+
+    return iml
+
+
+def upload_geo_data(geo_data_file_path: pathlib.Path, here_creds_file_path: pathlib.Path):
+    """
+    geo_data_file_path - Path of the file containing the geospatial activity
+                         data in GeoJSON format.
+    here_creds_file_path - Path of the file containing the HERE platform
+                           credentials.
+    """
+
+    # Get a HERE IML object for the Strava Analysis Tool layer
+    iml = _get_here_iml(here_creds_file_path=here_creds_file_path)
+
+    # Read the contents of the geo data file
+    with geo_data_file_path.open('r', encoding='utf-8') as geo_data_file:
+        geo_data = geojson.load(geo_data_file)
+
+        if geo_data:
+            # Upload all the data
+            iml.layer.write_features(features=geo_data)

--- a/here_xyz.py
+++ b/here_xyz.py
@@ -85,6 +85,11 @@ def _get_here_iml(here_creds_file_path: pathlib.Path) -> IML:
 
 def upload_geo_data(geo_data_file_path: pathlib.Path, here_creds_file_path: pathlib.Path):
     """
+    Upload the geospatial activity data to an interactive mapping layer (IML)
+    on the HERE platform. This layer can be used by the map created in HERE
+    Studio.
+
+    Arguments:
     geo_data_file_path - Path of the file containing the geospatial activity
                          data in GeoJSON format.
     here_creds_file_path - Path of the file containing the HERE platform

--- a/strava_analysis_tool.py
+++ b/strava_analysis_tool.py
@@ -86,7 +86,7 @@ def main():
     pandas.set_option('precision', 2)
 
     # Get a list of detailed data for all Strava activities
-    activity_df = strava_data.get_activity_data(pathlib.Path(config['paths']['tokens_file']),
+    activity_df = strava_data.get_activity_data(pathlib.Path(config['paths']['strava_tokens_file']),
                                                 pathlib.Path(config['paths']['activity_data_file']),
                                                 args.refresh_data,
                                                 config['data']['enable_reverse_geocoding'])
@@ -125,8 +125,11 @@ def main():
         geo.export_geo_data_file(config['paths']['geo_data_file'], activity_df)
 
         if args.export_upload_geo_data:
-            # Upload the geospatial data to HERE XYZ
-            here_xyz.upload_geo_data(config['paths']['geo_data_file'])
+            # Upload the geospatial data to HERE
+            here_xyz.upload_geo_data(
+            geo_data_file_path=pathlib.Path(config['paths']['geo_data_file']),
+            here_creds_file_path=pathlib.Path(config['paths']['here_creds_file'])
+            )
 
     if args.activity_count_plot:
         # Generate and display a plot of activity counts over time


### PR DESCRIPTION
Migrates to HERE's new platform and remove calls to the now deprecated 'Data Hub' as described in #89. The tool creates a catalog and Interactive Mapping Layer (IML) to store all uploaded geospatial activity data.

The README contains instructions on how to obtain OAuth 2.0 credentials for the HERE platform. The path to the credentials file can be configured in `config.toml`.